### PR TITLE
Remove default_locale property from manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,6 @@
 	"name": "Convert LinkedIn Profile to Printable",
 	"description": "Converts a LinkedIn Profile page into a printable format",
 	"author": "Aaron T. Grogg",
-	"default_locale": "en",
 	"version": "1.0",
 	"homepage_url": "https://github.com/aarontgrogg/Convert-LinkedIn-Profile-to-Printable",
 


### PR DESCRIPTION
This will avoid the following error message:
"Default locale was specified, but _locales subtree is missing."

Fixes #1 
